### PR TITLE
Create nersc batchspawner

### DIFF
--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -269,7 +269,8 @@ class BatchSpawnerBase(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
-        if not self.port:
+        if (jupyterhub.version_info < (0,7) and not self.user.server.port) or \
+           (jupyterhub.version_info > (0,6) and not self.port):
             self.port = random_port()
             self.db.commit()
         job = yield self.submit_batch_script()

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -269,8 +269,11 @@ class BatchSpawnerBase(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
-        if (jupyterhub.version_info < (0,7) and not self.user.server.port) or \
-           (jupyterhub.version_info > (0,6) and not self.port):
+        if self.user and self.user.server and self.user.server.port:
+            self.port = self.user.server.port
+            self.db.commit()
+        elif (jupyterhub.version_info < (0,7) and not self.user.server.port)  or \
+             (jupyterhub.version_info >= (0,7) and not self.port):
             self.port = random_port()
             self.db.commit()
         job = yield self.submit_batch_script()

--- a/batchspawner/batchspawner.py
+++ b/batchspawner/batchspawner.py
@@ -31,6 +31,7 @@ from traitlets import (
 
 from jupyterhub.utils import random_port
 from jupyterhub.spawner import set_user_setuid
+import jupyterhub
 
 @gen.coroutine
 def run_command(cmd, input=None, env=None):
@@ -268,8 +269,8 @@ class BatchSpawnerBase(Spawner):
     @gen.coroutine
     def start(self):
         """Start the process"""
-        if not self.user.server.port:
-            self.user.server.port = random_port()
+        if not self.port:
+            self.port = random_port()
             self.db.commit()
         job = yield self.submit_batch_script()
 
@@ -291,13 +292,17 @@ class BatchSpawnerBase(Spawner):
                 assert self.state_ispending()
             yield gen.sleep(self.startup_poll_interval)
 
-        self.user.server.ip = self.state_gethost()
+        self.ip = self.state_gethost()
+        if jupyterhub.version_info < (0,7):
+            # store on user for pre-jupyterhub-0.7:
+            self.user.server.port = self.port
+            self.user.server.ip = self.ip
         self.db.commit()
         self.log.info("Notebook server job {0} started at {1}:{2}".format(
-                        self.job_id, self.user.server.ip, self.user.server.port)
+                        self.job_id, self.ip, self.port)
             )
 
-        return self.user.server.ip, self.user.server.port
+        return self.ip, self.port
 
     @gen.coroutine
     def stop(self, now=False):
@@ -317,7 +322,7 @@ class BatchSpawnerBase(Spawner):
             yield gen.sleep(1.0)
         if self.job_id:
             self.log.warn("Notebook server job {0} at {1}:{2} possibly failed to terminate".format(
-                             self.job_id, self.user.server.ip, self.user.server.port)
+                             self.job_id, self.ip, self.port)
                 )
 
 import re

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -90,7 +90,7 @@ def test_spawner_state_reload(db, io_loop):
     spawner.clear_state()
     assert spawner.get_state() == {}
     spawner.load_state(state)
-    if version_info < (0,8):
+    if version_info < (0,7):
         check_ip(spawner, testhost)
     else:
         check_ip(spawner, '0.0.0.0')

--- a/batchspawner/tests/test_spawners.py
+++ b/batchspawner/tests/test_spawners.py
@@ -90,7 +90,10 @@ def test_spawner_state_reload(db, io_loop):
     spawner.clear_state()
     assert spawner.get_state() == {}
     spawner.load_state(state)
-    check_ip(spawner, testhost)
+    if version_info < (0,8):
+        check_ip(spawner, testhost)
+    else:
+        check_ip(spawner, '0.0.0.0')
     assert spawner.job_id == testjob
 
 def test_submit_failure(db, io_loop):


### PR DESCRIPTION
This PR incorporates commits from other forks that seem to be needed to make batchspawner work.  I think eventually those things will be merged into the main jupyterhub fork but so far that hasn't happened.

The important part of this PR for us is that it adds a prototype batch spawner implementation that accounts for the:

* ssh method of starting/polling/stopping jobs
* uses a SDN remote-side script to get the job ID and external IP
* custom `get_env()` for the job script
* SDN associate call in the job template
* job template satisfying requirements to run jobs for now

@shreddd @scanon I think the ssh spawn and get_env stuff we need can't be just done via existing SlurmSpawner config options, but see if you can prove me wrong there.  I think we need the `get_env()` stuff like we have in `sshspawner` but you could see if we should change that.

This is set up to work on Gerty for now where we can manage SDN and so on.

@shreddd @scanon please *do* review this.  But in the long run I think the plan should be for us to set up a separate repo for spawner bits we need to customize for `profilesspawner` and `batchspawner` --- but in the even longer run we will want to figure out what abstractions can go into those packages that maybe make our separate repo for spawning at NERSC go away.